### PR TITLE
Ensure buffer capacity is always > 0

### DIFF
--- a/contracts/Buffer.sol
+++ b/contracts/Buffer.sol
@@ -6,9 +6,10 @@ library Buffer {
         uint capacity;
     }
 
+    uint constant capacityMask = (2 ** 256) - 32; // ~0x1f
+
     function init(buffer memory buf, uint _capacity) internal pure {
-        uint capacity = _capacity;
-        if(capacity % 32 != 0) capacity += 32 - (capacity % 32);
+        uint capacity = (_capacity + 0x1f) & capacityMask;
         // Allocate space for the buffer data
         buf.capacity = capacity;
         assembly {

--- a/contracts/Buffer.sol
+++ b/contracts/Buffer.sol
@@ -123,7 +123,7 @@ library Buffer {
             let bufptr := mload(buf)
             // Length of existing buffer data
             let buflen := mload(bufptr)
-            // Address = buffer address + buffer length + sizeof(buffer length) + len
+            // Address = buffer address + buffer length + len
             let dest := add(add(bufptr, buflen), len)
             mstore(dest, or(and(mload(dest), not(mask)), data))
             // Update buffer length

--- a/contracts/Buffer.sol
+++ b/contracts/Buffer.sol
@@ -9,7 +9,7 @@ library Buffer {
     uint constant capacityMask = (2 ** 256) - 32; // ~0x1f
 
     function init(buffer memory buf, uint _capacity) internal pure {
-        uint capacity = (_capacity + 0x1f) & capacityMask;
+        uint capacity = max(32, (_capacity + 0x1f) & capacityMask);
         // Allocate space for the buffer data
         buf.capacity = capacity;
         assembly {

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
         if (msg.sender == owner) _;
     }
 
-    function Migrations() public {
+    constructor() public {
         owner = msg.sender;
     }
 

--- a/test/TestBuffer.sol
+++ b/test/TestBuffer.sol
@@ -72,4 +72,13 @@ contract TestBuffer {
       Assert.equal(buf.buf.length, 96, "Expected buffer length to be 33");
       Assert.equal(string(buf.buf), "012345678901234567890123456789010123456789012345678901234567890101234567890123456789012345678901", "Unexpected buffer contents");
     }
+
+    function testBufferZeroSized() public {
+      Buffer.buffer memory buf;
+      Buffer.init(buf, 0);
+      buf.append("first");
+      Assert.equal(buf.capacity, 32, "Expected buffer capacity to be 32");
+      Assert.equal(buf.buf.length, 5, "Expected buffer length to be 5");
+      Assert.equal(string(buf.buf), "first", "Unexpected buffer contents");
+    }
 }


### PR DESCRIPTION
We've noticed that it's possible for `init` to accidentally get called with 0 in a couple of ways, and this tends to cause some very strange problems to occur.

Because `mstore(0x40, add(ptr, capacity))` with a capacity of 0 will not actually move the free storage pointer, the next use of memory will overwrite the buffer. When init is eventually called again, it tries to append what was in the old buffer to the new one. Chaos ensues. If a large uint256 value was stored you should run out of gas. If `bytes` were written you'll get a copy of them in your buffer. 

Also minor changes: comment trimmed to remove `+ sizeof(buffer length)` which was not needed and used new ctor syntax in migrations.