### PR TITLE
Make sure encodeUint also supports bignums

### DIFF
--- a/test/TestCBOR.sol
+++ b/test/TestCBOR.sol
@@ -41,7 +41,7 @@ contract TestCBOR {
         return buf.buf;
     }
 
-    function getTestDataBig() public pure returns(bytes memory) {
+    function getTestDataBigInt() public pure returns(bytes memory) {
         Buffer.buffer memory buf;
         Buffer.init(buf, 28);
 
@@ -52,6 +52,23 @@ contract TestCBOR {
         buf.encodeInt(28948022309329048855892746252171976963317496166410141009864396001978282409984);
         buf.encodeInt(-18446744073709551617);
         buf.encodeInt(-28948022309329048855892746252171976963317496166410141009864396001978282409984);
+        buf.endSequence();
+
+        buf.endSequence();
+
+        return buf.buf;
+    }
+
+    function getTestDataBigUint() public pure returns(bytes memory) {
+        Buffer.buffer memory buf;
+        Buffer.init(buf, 28);
+
+        buf.startMap();
+        buf.encodeString("ubignums");
+        buf.startArray();
+        buf.encodeUInt(18446744073709551616);
+        buf.encodeUInt(28948022309329048855892746252171976963317496166410141009864396001978282409984);
+        buf.encodeUInt(115792089237316195423570985008687907853269984665640564039457584007913129639935);
         buf.endSequence();
 
         buf.endSequence();

--- a/test/testcbor.js
+++ b/test/testcbor.js
@@ -13,9 +13,9 @@ contract('CBOR', function(accounts) {
     });
   });
 
-  it('returns > 8 byte numbers as bytes', async function() {
+  it('returns > 8 byte int as bytes', async function() {
     var test = await TestCBOR.new();
-    var result = await test.getTestDataBig();
+    var result = await test.getTestDataBigInt();
 
     // js CBOR library doesn't support negative bignum encodings as described
     // in the RFC, so we have to verify the raw codes
@@ -42,6 +42,37 @@ contract('CBOR', function(accounts) {
                           // int(28948022309329048855892746252171976963317496166410141009864396001978282409983)
       'ff' +              // primitive(*)
       'ff'                // primitive(*)
+    );
+  });
+
+  it('returns > 8 byte uint as bytes', async function() {
+    var test = await TestCBOR.new();
+    var result = await test.getTestDataBigUint();
+
+    // js CBOR library doesn't support negative bignum encodings as described
+    // in the RFC, so we have to verify the raw codes
+    // bf
+    // 68
+    // 756269676e756d739fc2582
+    assert.equal(result, '0x' +
+      'bf' +                // map(*)
+      '68' +                // text(7)
+      '756269676e756d73' +  // "ubignums"
+      '9f' +                // array(*)
+      'c2' +                // tag(2) == unsigned bignum
+      '5820' +              // bytes(32)
+      '0000000000000000000000000000000000000000000000010000000000000000' +
+                            // uint(18446744073709551616)
+      'c2' +                // tag(2) == unsigned bignum
+      '5820' +              // bytes(32)
+      '4000000000000000000000000000000000000000000000000000000000000000' +
+                            // uint(28948022309329048855892746252171976963317496166410141009864396001978282409984)
+      'c2' +                // tag(2) == unsigned bignum
+      '5820' +              // bytes(32)
+      'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff' +
+                            // uint(115792089237316195423570985008687907853269984665640564039457584007913129639935)
+      'ff' +                // primitive(*)
+      'ff'                  // primitive(*)
     );
   });
 });


### PR DESCRIPTION
 * `encodeUint` now handles bignums.
 * Changed `encodeType` to `encodeFixedNumeric` to better represent its purpose, it now takes a uint64, so the else if can go away and "unreachable" code no longer exists in that function.