### PR TITLE
CBOR encoding enhancements

### DIFF
--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -56,59 +56,59 @@ library CBOR {
     }
 
     function writeUInt64(CBORBuffer memory buf, uint64 value) internal pure {
-        encodeFixedNumeric(buf, MAJOR_TYPE_INT, value);
+        writeFixedNumeric(buf, MAJOR_TYPE_INT, value);
     }
 
     function writeInt64(CBORBuffer memory buf, int64 value) internal pure {
         if(value >= 0) {
-            encodeFixedNumeric(buf, MAJOR_TYPE_INT, uint64(value));
+            writeFixedNumeric(buf, MAJOR_TYPE_INT, uint64(value));
         } else{
-            encodeFixedNumeric(buf, MAJOR_TYPE_NEGATIVE_INT, uint64(-1 - value));
+            writeFixedNumeric(buf, MAJOR_TYPE_NEGATIVE_INT, uint64(-1 - value));
         }
     }
 
     function writeBytes(CBORBuffer memory buf, bytes memory value) internal pure {
-        encodeFixedNumeric(buf, MAJOR_TYPE_BYTES, uint64(value.length));
+        writeFixedNumeric(buf, MAJOR_TYPE_BYTES, uint64(value.length));
         buf.buf.append(value);
     }
 
     function writeString(CBORBuffer memory buf, string memory value) internal pure {
-        encodeFixedNumeric(buf, MAJOR_TYPE_STRING, uint64(bytes(value).length));
+        writeFixedNumeric(buf, MAJOR_TYPE_STRING, uint64(bytes(value).length));
         buf.buf.append(bytes(value));
     }
 
     function writeBool(CBORBuffer memory buf, bool value) internal pure {
-        encodeContentFree(buf, value ? CBOR_TRUE : CBOR_FALSE);
+        writeContentFree(buf, value ? CBOR_TRUE : CBOR_FALSE);
     }
 
     function writeNull(CBORBuffer memory buf) internal pure {
-        encodeContentFree(buf, CBOR_NULL);
+        writeContentFree(buf, CBOR_NULL);
     }
 
     function writeUndefined(CBORBuffer memory buf) internal pure {
-        encodeContentFree(buf, CBOR_UNDEFINED);
+        writeContentFree(buf, CBOR_UNDEFINED);
     }
 
     function startArray(CBORBuffer memory buf) internal pure {
-        encodeIndefiniteLengthType(buf, MAJOR_TYPE_ARRAY);
+        writeIndefiniteLengthType(buf, MAJOR_TYPE_ARRAY);
         buf.depth += 1;
     }
 
     function startFixedArray(CBORBuffer memory buf, uint64 length) internal pure {
-        encodeDefiniteLengthType(buf, MAJOR_TYPE_ARRAY, length);
+        writeDefiniteLengthType(buf, MAJOR_TYPE_ARRAY, length);
     }
 
     function startMap(CBORBuffer memory buf) internal pure {
-        encodeIndefiniteLengthType(buf, MAJOR_TYPE_MAP);
+        writeIndefiniteLengthType(buf, MAJOR_TYPE_MAP);
         buf.depth += 1;
     }
 
     function startFixedMap(CBORBuffer memory buf, uint64 length) internal pure {
-        encodeDefiniteLengthType(buf, MAJOR_TYPE_MAP, length);
+        writeDefiniteLengthType(buf, MAJOR_TYPE_MAP, length);
     }
 
     function endSequence(CBORBuffer memory buf) internal pure {
-        encodeIndefiniteLengthType(buf, MAJOR_TYPE_CONTENT_FREE);
+        writeIndefiniteLengthType(buf, MAJOR_TYPE_CONTENT_FREE);
         buf.depth -= 1;
     }
 
@@ -167,7 +167,7 @@ library CBOR {
         startArray(buf);
     }
 
-    function encodeFixedNumeric(
+    function writeFixedNumeric(
         CBORBuffer memory buf,
         uint8 major,
         uint64 value
@@ -189,21 +189,21 @@ library CBOR {
         }
     }
 
-    function encodeIndefiniteLengthType(CBORBuffer memory buf, uint8 major)
+    function writeIndefiniteLengthType(CBORBuffer memory buf, uint8 major)
         private
         pure
     {
         buf.buf.appendUint8(uint8((major << 5) | 31));
     }
 
-    function encodeDefiniteLengthType(CBORBuffer memory buf, uint8 major, uint64 length)
+    function writeDefiniteLengthType(CBORBuffer memory buf, uint8 major, uint64 length)
         private
         pure
     {
-        encodeFixedNumeric(buf, major, length);
+        writeFixedNumeric(buf, major, length);
     }
 
-    function encodeContentFree(CBORBuffer memory buf, uint8 value) private pure {
+    function writeContentFree(CBORBuffer memory buf, uint8 value) private pure {
         buf.buf.appendUint8(uint8((MAJOR_TYPE_CONTENT_FREE << 5) | value));
     }
 }

--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.4.19 <0.9.0;
+pragma solidity ^0.8.4;
 
 import "@ensdomains/buffer/contracts/Buffer.sol";
 

--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -9,6 +9,8 @@ library CBOR {
     struct CBORBuffer {
         Buffer.buffer buf;
         uint256 depth;
+        bool is_fixed_size_sequence[32];
+        uint64 remaining_items_in_sequence[32];
     }
 
     uint8 private constant MAJOR_TYPE_INT = 0;
@@ -40,132 +42,147 @@ library CBOR {
     }
 
     function writeUInt256(CBORBuffer memory buf, uint256 value) internal pure {
+        decrementRemainingItemsInSequence(buf);
         buf.buf.appendUint8(uint8((MAJOR_TYPE_TAG << 5) | TAG_TYPE_BIGNUM));
-        writeBytes(buf, abi.encode(value));
+        writeBytesInternal(buf, abi.encode(value));
     }
 
     function writeInt256(CBORBuffer memory buf, int256 value) internal pure {
-        if (value < 0) {
-            buf.buf.appendUint8(
-                uint8((MAJOR_TYPE_TAG << 5) | TAG_TYPE_NEGATIVE_BIGNUM)
-            );
-            writeBytes(buf, abi.encode(uint256(-1 - value)));
-        } else {
-            writeUInt256(buf, uint256(value));
-        }
+        decrementRemainingItemsInSequence(buf);
+        writeInt256Internal(buf, value);
     }
 
     function writeUInt64(CBORBuffer memory buf, uint64 value) internal pure {
-        writeFixedNumeric(buf, MAJOR_TYPE_INT, value);
+        decrementRemainingItemsInSequence(buf);
+        writeUInt64Internal(buf, value);
     }
 
     function writeInt64(CBORBuffer memory buf, int64 value) internal pure {
-        if(value >= 0) {
-            writeFixedNumeric(buf, MAJOR_TYPE_INT, uint64(value));
-        } else{
-            writeFixedNumeric(buf, MAJOR_TYPE_NEGATIVE_INT, uint64(-1 - value));
-        }
+        decrementRemainingItemsInSequence(buf);
+        writeInt64Internal(buf, value);
     }
 
     function writeBytes(CBORBuffer memory buf, bytes memory value) internal pure {
-        writeFixedNumeric(buf, MAJOR_TYPE_BYTES, uint64(value.length));
-        buf.buf.append(value);
+        decrementRemainingItemsInSequence(buf);
+        writeBytesInternal(buf, value);
     }
 
     function writeString(CBORBuffer memory buf, string memory value) internal pure {
-        writeFixedNumeric(buf, MAJOR_TYPE_STRING, uint64(bytes(value).length));
-        buf.buf.append(bytes(value));
+        decrementRemainingItemsInSequence(buf);
+        writeStringInternal(buf, value);
     }
 
     function writeBool(CBORBuffer memory buf, bool value) internal pure {
-        writeContentFree(buf, value ? CBOR_TRUE : CBOR_FALSE);
+        decrementRemainingItemsInSequence(buf);
+        writeBoolInternal(buf, value);
     }
 
     function writeNull(CBORBuffer memory buf) internal pure {
-        writeContentFree(buf, CBOR_NULL);
+        decrementRemainingItemsInSequence(buf);
+        writeNullInternal(buf);
     }
 
     function writeUndefined(CBORBuffer memory buf) internal pure {
-        writeContentFree(buf, CBOR_UNDEFINED);
+        decrementRemainingItemsInSequence(buf);
+        writeUndefinedInternal(buf);
     }
 
     function startArray(CBORBuffer memory buf) internal pure {
-        writeIndefiniteLengthType(buf, MAJOR_TYPE_ARRAY);
-        buf.depth += 1;
+        decrementRemainingItemsInSequence(buf);
+        markSequenceStart(buf, false, 0);
+        startArrayInternal(buf);
     }
 
     function startFixedArray(CBORBuffer memory buf, uint64 length) internal pure {
+        decrementRemainingItemsInSequence(buf);
+        markSequenceStart(buf, true, length);
         writeDefiniteLengthType(buf, MAJOR_TYPE_ARRAY, length);
     }
 
     function startMap(CBORBuffer memory buf) internal pure {
-        writeIndefiniteLengthType(buf, MAJOR_TYPE_MAP);
-        buf.depth += 1;
+        decrementRemainingItemsInSequence(buf);
+        markSequenceStart(buf, false, 0);
+        startMapInternal(buf);
     }
 
     function startFixedMap(CBORBuffer memory buf, uint64 length) internal pure {
+        decrementRemainingItemsInSequence(buf);
+        markSequenceStart(buf, true, length);
         writeDefiniteLengthType(buf, MAJOR_TYPE_MAP, length);
     }
 
     function endSequence(CBORBuffer memory buf) internal pure {
+        markSequenceEnd(buf);
         writeIndefiniteLengthType(buf, MAJOR_TYPE_CONTENT_FREE);
-        buf.depth -= 1;
     }
 
     function writeKVString(CBORBuffer memory buf, string memory key, string memory value) internal pure {
-        writeString(buf, key);
-        writeString(buf, value);
+        decrementRemainingItemsInSequence(buf);
+        writeStringInternal(buf, key);
+        writeStringInternal(buf, value);
     }
 
     function writeKVBytes(CBORBuffer memory buf, string memory key, bytes memory value) internal pure {
-        writeString(buf, key);
-        writeBytes(buf, value);
+        decrementRemainingItemsInSequence(buf);
+        writeStringInternal(buf, key);
+        writeBytesInternal(buf, value);
     }
 
     function writeKVUInt256(CBORBuffer memory buf, string memory key, uint256 value) internal pure {
-        writeString(buf, key);
-        writeUInt256(buf, value);
+        decrementRemainingItemsInSequence(buf);
+        writeStringInternal(buf, key);
+        writeUInt256Internal(buf, value);
     }
 
     function writeKVInt256(CBORBuffer memory buf, string memory key, int256 value) internal pure {
-        writeString(buf, key);
-        writeInt256(buf, value);
+        decrementRemainingItemsInSequence(buf);
+        writeStringInternal(buf, key);
+        writeInt256Internal(buf, value);
     }
 
     function writeKVUInt64(CBORBuffer memory buf, string memory key, uint64 value) internal pure {
-        writeString(buf, key);
-        writeUInt64(buf, value);
+        decrementRemainingItemsInSequence(buf);
+        writeStringInternal(buf, key);
+        writeUInt64Internal(buf, value);
     }
 
     function writeKVInt64(CBORBuffer memory buf, string memory key, int64 value) internal pure {
-        writeString(buf, key);
-        writeInt64(buf, value);
+        decrementRemainingItemsInSequence(buf);
+        writeStringInternal(buf, key);
+        writeInt64Internal(buf, value);
     }
 
     function writeKVBool(CBORBuffer memory buf, string memory key, bool value) internal pure {
-        writeString(buf, key);
-        writeBool(buf, value);
+        decrementRemainingItemsInSequence(buf);
+        writeStringInternal(buf, key);
+        writeBoolInternal(buf, value);
     }
 
     function writeKVNull(CBORBuffer memory buf, string memory key) internal pure {
-        writeString(buf, key);
-        writeNull(buf);
+        decrementRemainingItemsInSequence(buf);
+        writeStringInternal(buf, key);
+        writeNullInternal(buf);
     }
 
     function writeKVUndefined(CBORBuffer memory buf, string memory key) internal pure {
-        writeString(buf, key);
-        writeUndefined(buf);
+        decrementRemainingItemsInSequence(buf);
+        writeStringInternal(buf, key);
+        writeUndefinedInternal(buf);
     }
 
     function writeKVMap(CBORBuffer memory buf, string memory key) internal pure {
-        writeString(buf, key);
-        startMap(buf);
+        decrementRemainingItemsInSequence(buf);
+        writeStringInternal(buf, key);
+        startMapInternal(buf);
     }
 
     function writeKVArray(CBORBuffer memory buf, string memory key) internal pure {
-        writeString(buf, key);
-        startArray(buf);
+        decrementRemainingItemsInSequence(buf);
+        writeStringInternal(buf, key);
+        startArrayInternal(buf);
     }
+
+
 
     function writeFixedNumeric(
         CBORBuffer memory buf,
@@ -189,6 +206,59 @@ library CBOR {
         }
     }
 
+    function writeInt256Internal(CBORBuffer memory buf, int256 value) private pure {
+        if (value < 0) {
+            buf.buf.appendUint8(
+                uint8((MAJOR_TYPE_TAG << 5) | TAG_TYPE_NEGATIVE_BIGNUM)
+            );
+            writeBytesInternal(buf, abi.encode(uint256(-1 - value)));
+        } else {
+            writeUInt256Internal(buf, uint256(value));
+        }
+    }
+
+    function writeBytesInternal(CBORBuffer memory buf, bytes memory value) private pure {
+        writeFixedNumeric(buf, MAJOR_TYPE_BYTES, uint64(value.length));
+        buf.buf.append(value);
+    }
+
+    function writeUInt64Internal(CBORBuffer memory buf, uint64 value) private pure {
+        writeFixedNumeric(buf, MAJOR_TYPE_INT, value);
+    }
+
+    function writeInt64Internal(CBORBuffer memory buf, int64 value) private pure {
+        if(value >= 0) {
+            writeFixedNumeric(buf, MAJOR_TYPE_INT, uint64(value));
+        } else{
+            writeFixedNumeric(buf, MAJOR_TYPE_NEGATIVE_INT, uint64(-1 - value));
+        }
+    }
+
+    function writeBoolInternal(CBORBuffer memory buf, bool value) private pure {
+        writeContentFree(buf, value ? CBOR_TRUE : CBOR_FALSE);
+    }
+
+    function writeUndefinedInternal(CBORBuffer memory buf) private pure {
+        writeContentFree(buf, CBOR_UNDEFINED);
+    }
+
+    function writeNullInternal(CBORBuffer memory buf) private pure {
+        writeContentFree(buf, CBOR_NULL);
+    }
+
+    function writeStringInternal(CBORBuffer memory buf, string memory key) private pure {
+        writeFixedNumeric(buf, MAJOR_TYPE_STRING, uint64(bytes(value).length));
+        buf.buf.append(bytes(value));
+    }
+
+    function startArrayInternal(CBORBuffer memory buf) private pure {
+        writeIndefiniteLengthType(buf, MAJOR_TYPE_ARRAY);
+    }
+
+    function startMapInternal(CBORBuffer memory buf) private pure {
+        writeIndefiniteLengthType(buf, MAJOR_TYPE_MAP);
+    }
+
     function writeIndefiniteLengthType(CBORBuffer memory buf, uint8 major)
         private
         pure
@@ -205,5 +275,42 @@ library CBOR {
 
     function writeContentFree(CBORBuffer memory buf, uint8 value) private pure {
         buf.buf.appendUint8(uint8((MAJOR_TYPE_CONTENT_FREE << 5) | value));
+    }
+
+    function decrementRemainingItemsInSequence(CBORBuffer memory buf) private pure {
+        if (buf.depth == 0) {
+            return;
+        }
+        uint index = buf.depth - 1;
+        if (buf.is_fixed_size_sequence[index] == true) {
+            require(buf.remaining_items_in_sequence[index] > 0 "Invalid CBOR");
+            if (buf.remaining_items_in_sequence[index] == 1) {
+                buf.depth -= 1;
+                return
+            }
+            buf.remaining_items_in_sequence[index] -= 1;
+        }
+    }
+
+    function markSequenceStart(CBORBuffer memory buf, bool is_fixed_sized, uint64 total_items) private pure {
+        require(buf.depth < 32, "Exceeded max nested depth");
+        if  (is_fixed_sized) {
+            if (total_items == 0) {
+                return
+            }
+            buf.is_fixed_size_sequence[buf.depth] = true;
+            buf.remaining_items_in_sequence[buf.depth] = total_items;
+        } else {
+            buf.is_fixed_size_sequence[buf.depth] = false;
+        }
+        buf.depth += 1;
+    }
+    function markSequenceEnd(CBORBuffer memory buf) private pure {
+        require(buf.depth > 0, "Invalid CBOR");
+        uint index = buf.depth - 1;
+        if (buf.is_fixed_size_sequence[index]) {
+            require(buf.remaining_items_in_sequence[index] == 0 "Invalid CBOR");
+        }
+        buf.depth -= 1;
     }
 }

--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -3,6 +3,19 @@ pragma solidity ^0.8.4;
 
 import "@ensdomains/buffer/contracts/Buffer.sol";
 
+/**
+* @dev A library for populating CBOR encoded payload in Solidity.
+*
+* https://datatracker.ietf.org/doc/html/rfc7049
+*
+* The library offers various write* and start* methods to encode values of different types.
+* The resulted buffer can be obtained with data() method.
+* Encoding of primitive types is staightforward, whereas encoding of sequences can result
+* in an invalid CBOR if start/write/end flow is violated.
+* For the purpose of gas saving, the library does not verify start/write/end flow internally,
+* except for nested start/end pairs.
+*/
+
 library CBOR {
     using Buffer for Buffer.buffer;
 

--- a/contracts/CBOR.sol
+++ b/contracts/CBOR.sol
@@ -9,8 +9,6 @@ library CBOR {
     struct CBORBuffer {
         Buffer.buffer buf;
         uint256 depth;
-        bool is_fixed_size_sequence[32];
-        uint64 remaining_items_in_sequence[32];
     }
 
     uint8 private constant MAJOR_TYPE_INT = 0;
@@ -42,147 +40,132 @@ library CBOR {
     }
 
     function writeUInt256(CBORBuffer memory buf, uint256 value) internal pure {
-        decrementRemainingItemsInSequence(buf);
         buf.buf.appendUint8(uint8((MAJOR_TYPE_TAG << 5) | TAG_TYPE_BIGNUM));
-        writeBytesInternal(buf, abi.encode(value));
+        writeBytes(buf, abi.encode(value));
     }
 
     function writeInt256(CBORBuffer memory buf, int256 value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeInt256Internal(buf, value);
+        if (value < 0) {
+            buf.buf.appendUint8(
+                uint8((MAJOR_TYPE_TAG << 5) | TAG_TYPE_NEGATIVE_BIGNUM)
+            );
+            writeBytes(buf, abi.encode(uint256(-1 - value)));
+        } else {
+            writeUInt256(buf, uint256(value));
+        }
     }
 
     function writeUInt64(CBORBuffer memory buf, uint64 value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeUInt64Internal(buf, value);
+        writeFixedNumeric(buf, MAJOR_TYPE_INT, value);
     }
 
     function writeInt64(CBORBuffer memory buf, int64 value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeInt64Internal(buf, value);
+        if(value >= 0) {
+            writeFixedNumeric(buf, MAJOR_TYPE_INT, uint64(value));
+        } else{
+            writeFixedNumeric(buf, MAJOR_TYPE_NEGATIVE_INT, uint64(-1 - value));
+        }
     }
 
     function writeBytes(CBORBuffer memory buf, bytes memory value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeBytesInternal(buf, value);
+        writeFixedNumeric(buf, MAJOR_TYPE_BYTES, uint64(value.length));
+        buf.buf.append(value);
     }
 
     function writeString(CBORBuffer memory buf, string memory value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeStringInternal(buf, value);
+        writeFixedNumeric(buf, MAJOR_TYPE_STRING, uint64(bytes(value).length));
+        buf.buf.append(bytes(value));
     }
 
     function writeBool(CBORBuffer memory buf, bool value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeBoolInternal(buf, value);
+        writeContentFree(buf, value ? CBOR_TRUE : CBOR_FALSE);
     }
 
     function writeNull(CBORBuffer memory buf) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeNullInternal(buf);
+        writeContentFree(buf, CBOR_NULL);
     }
 
     function writeUndefined(CBORBuffer memory buf) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeUndefinedInternal(buf);
+        writeContentFree(buf, CBOR_UNDEFINED);
     }
 
     function startArray(CBORBuffer memory buf) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        markSequenceStart(buf, false, 0);
-        startArrayInternal(buf);
+        writeIndefiniteLengthType(buf, MAJOR_TYPE_ARRAY);
+        buf.depth += 1;
     }
 
     function startFixedArray(CBORBuffer memory buf, uint64 length) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        markSequenceStart(buf, true, length);
         writeDefiniteLengthType(buf, MAJOR_TYPE_ARRAY, length);
     }
 
     function startMap(CBORBuffer memory buf) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        markSequenceStart(buf, false, 0);
-        startMapInternal(buf);
+        writeIndefiniteLengthType(buf, MAJOR_TYPE_MAP);
+        buf.depth += 1;
     }
 
     function startFixedMap(CBORBuffer memory buf, uint64 length) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        markSequenceStart(buf, true, length);
         writeDefiniteLengthType(buf, MAJOR_TYPE_MAP, length);
     }
 
     function endSequence(CBORBuffer memory buf) internal pure {
-        markSequenceEnd(buf);
         writeIndefiniteLengthType(buf, MAJOR_TYPE_CONTENT_FREE);
+        buf.depth -= 1;
     }
 
     function writeKVString(CBORBuffer memory buf, string memory key, string memory value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeStringInternal(buf, key);
-        writeStringInternal(buf, value);
+        writeString(buf, key);
+        writeString(buf, value);
     }
 
     function writeKVBytes(CBORBuffer memory buf, string memory key, bytes memory value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeStringInternal(buf, key);
-        writeBytesInternal(buf, value);
+        writeString(buf, key);
+        writeBytes(buf, value);
     }
 
     function writeKVUInt256(CBORBuffer memory buf, string memory key, uint256 value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeStringInternal(buf, key);
-        writeUInt256Internal(buf, value);
+        writeString(buf, key);
+        writeUInt256(buf, value);
     }
 
     function writeKVInt256(CBORBuffer memory buf, string memory key, int256 value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeStringInternal(buf, key);
-        writeInt256Internal(buf, value);
+        writeString(buf, key);
+        writeInt256(buf, value);
     }
 
     function writeKVUInt64(CBORBuffer memory buf, string memory key, uint64 value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeStringInternal(buf, key);
-        writeUInt64Internal(buf, value);
+        writeString(buf, key);
+        writeUInt64(buf, value);
     }
 
     function writeKVInt64(CBORBuffer memory buf, string memory key, int64 value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeStringInternal(buf, key);
-        writeInt64Internal(buf, value);
+        writeString(buf, key);
+        writeInt64(buf, value);
     }
 
     function writeKVBool(CBORBuffer memory buf, string memory key, bool value) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeStringInternal(buf, key);
-        writeBoolInternal(buf, value);
+        writeString(buf, key);
+        writeBool(buf, value);
     }
 
     function writeKVNull(CBORBuffer memory buf, string memory key) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeStringInternal(buf, key);
-        writeNullInternal(buf);
+        writeString(buf, key);
+        writeNull(buf);
     }
 
     function writeKVUndefined(CBORBuffer memory buf, string memory key) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeStringInternal(buf, key);
-        writeUndefinedInternal(buf);
+        writeString(buf, key);
+        writeUndefined(buf);
     }
 
     function writeKVMap(CBORBuffer memory buf, string memory key) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeStringInternal(buf, key);
-        startMapInternal(buf);
+        writeString(buf, key);
+        startMap(buf);
     }
 
     function writeKVArray(CBORBuffer memory buf, string memory key) internal pure {
-        decrementRemainingItemsInSequence(buf);
-        writeStringInternal(buf, key);
-        startArrayInternal(buf);
+        writeString(buf, key);
+        startArray(buf);
     }
-
-
 
     function writeFixedNumeric(
         CBORBuffer memory buf,
@@ -206,59 +189,6 @@ library CBOR {
         }
     }
 
-    function writeInt256Internal(CBORBuffer memory buf, int256 value) private pure {
-        if (value < 0) {
-            buf.buf.appendUint8(
-                uint8((MAJOR_TYPE_TAG << 5) | TAG_TYPE_NEGATIVE_BIGNUM)
-            );
-            writeBytesInternal(buf, abi.encode(uint256(-1 - value)));
-        } else {
-            writeUInt256Internal(buf, uint256(value));
-        }
-    }
-
-    function writeBytesInternal(CBORBuffer memory buf, bytes memory value) private pure {
-        writeFixedNumeric(buf, MAJOR_TYPE_BYTES, uint64(value.length));
-        buf.buf.append(value);
-    }
-
-    function writeUInt64Internal(CBORBuffer memory buf, uint64 value) private pure {
-        writeFixedNumeric(buf, MAJOR_TYPE_INT, value);
-    }
-
-    function writeInt64Internal(CBORBuffer memory buf, int64 value) private pure {
-        if(value >= 0) {
-            writeFixedNumeric(buf, MAJOR_TYPE_INT, uint64(value));
-        } else{
-            writeFixedNumeric(buf, MAJOR_TYPE_NEGATIVE_INT, uint64(-1 - value));
-        }
-    }
-
-    function writeBoolInternal(CBORBuffer memory buf, bool value) private pure {
-        writeContentFree(buf, value ? CBOR_TRUE : CBOR_FALSE);
-    }
-
-    function writeUndefinedInternal(CBORBuffer memory buf) private pure {
-        writeContentFree(buf, CBOR_UNDEFINED);
-    }
-
-    function writeNullInternal(CBORBuffer memory buf) private pure {
-        writeContentFree(buf, CBOR_NULL);
-    }
-
-    function writeStringInternal(CBORBuffer memory buf, string memory key) private pure {
-        writeFixedNumeric(buf, MAJOR_TYPE_STRING, uint64(bytes(value).length));
-        buf.buf.append(bytes(value));
-    }
-
-    function startArrayInternal(CBORBuffer memory buf) private pure {
-        writeIndefiniteLengthType(buf, MAJOR_TYPE_ARRAY);
-    }
-
-    function startMapInternal(CBORBuffer memory buf) private pure {
-        writeIndefiniteLengthType(buf, MAJOR_TYPE_MAP);
-    }
-
     function writeIndefiniteLengthType(CBORBuffer memory buf, uint8 major)
         private
         pure
@@ -275,42 +205,5 @@ library CBOR {
 
     function writeContentFree(CBORBuffer memory buf, uint8 value) private pure {
         buf.buf.appendUint8(uint8((MAJOR_TYPE_CONTENT_FREE << 5) | value));
-    }
-
-    function decrementRemainingItemsInSequence(CBORBuffer memory buf) private pure {
-        if (buf.depth == 0) {
-            return;
-        }
-        uint index = buf.depth - 1;
-        if (buf.is_fixed_size_sequence[index] == true) {
-            require(buf.remaining_items_in_sequence[index] > 0 "Invalid CBOR");
-            if (buf.remaining_items_in_sequence[index] == 1) {
-                buf.depth -= 1;
-                return
-            }
-            buf.remaining_items_in_sequence[index] -= 1;
-        }
-    }
-
-    function markSequenceStart(CBORBuffer memory buf, bool is_fixed_sized, uint64 total_items) private pure {
-        require(buf.depth < 32, "Exceeded max nested depth");
-        if  (is_fixed_sized) {
-            if (total_items == 0) {
-                return
-            }
-            buf.is_fixed_size_sequence[buf.depth] = true;
-            buf.remaining_items_in_sequence[buf.depth] = total_items;
-        } else {
-            buf.is_fixed_size_sequence[buf.depth] = false;
-        }
-        buf.depth += 1;
-    }
-    function markSequenceEnd(CBORBuffer memory buf) private pure {
-        require(buf.depth > 0, "Invalid CBOR");
-        uint index = buf.depth - 1;
-        if (buf.is_fixed_size_sequence[index]) {
-            require(buf.remaining_items_in_sequence[index] == 0 "Invalid CBOR");
-        }
-        buf.depth -= 1;
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "https://github.com/smartcontractkit/solidity-cborutils.git"
   },
-  "version": "1.0.8",
+  "version": "2.0.0",
   "devDependencies": {
     "@nomiclabs/hardhat-truffle5": "^2.0.0",
     "@nomiclabs/hardhat-web3": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "@nomiclabs/hardhat-truffle5": "^2.0.0",
     "@nomiclabs/hardhat-web3": "^2.0.0",
     "hardhat": "^2.0.6",
-    "hardhat-gas-reporter": "^1.0.4"
+    "hardhat-gas-reporter": "^1.0.4",
+    "truffle-assertions": "^0.9.2"
   },
   "homepage": "https://github.com/smartcontractkit/solidity-cborutils",
   "license": "MIT",

--- a/test/TestCBOR.sol
+++ b/test/TestCBOR.sol
@@ -1,79 +1,115 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >= 0.4.19 < 0.9.0;
 
-import "@ensdomains/buffer/contracts/Buffer.sol";
 import "../contracts/CBOR.sol";
 
 contract TestCBOR {
-    using CBOR for Buffer.buffer;
+    using CBOR for CBOR.CBORBuffer;
 
     function getTestData() public pure returns(bytes memory) {
-        Buffer.buffer memory buf;
-        Buffer.init(buf, 64);
+        CBOR.CBORBuffer memory buf = CBOR.create(64);
 
         // Maps
         buf.startMap();
+
         // Short strings
-        buf.encodeString("key1");
-        buf.encodeString("value1");
+        buf.writeKVString("key1", "value1");
 
         // Longer strings
-        buf.encodeString("long");
-        buf.encodeString("This string is longer than 24 characters.");
+        buf.writeKVString("long", "This string is longer than 24 characters.");
+
+        // Bytes
+        buf.writeKVBytes("bytes", bytes("Test"));
+
+        // Bools, null, undefined
+        buf.writeKVBool("true", true);
+        buf.writeKVBool("false", false);
+        buf.writeKVNull("null");
+        buf.writeKVUndefined("undefined");
 
         // Arrays
-        buf.encodeString("array");
-        buf.startArray();
-        buf.encodeInt(0);
-        buf.encodeInt(1);
-        buf.encodeInt(23);
-        buf.encodeInt(24);
+        buf.writeKVArray("array");
+        buf.writeUInt64(0);
+        buf.writeUInt64(1);
+        buf.writeUInt64(23);
+        buf.writeUInt64(24);
 
         // 2, 4, and 8 byte numbers.
-        buf.encodeInt(0x100);
-        buf.encodeInt(0x10000);
-        buf.encodeInt(0x100000000);
+        buf.writeUInt64(0x100);
+        buf.writeUInt64(0x10000);
+        buf.writeUInt64(0x100000000);
 
         // Negative numbers
-        buf.encodeInt(-42);
+        buf.writeInt64(-42);
 
         buf.endSequence();
         buf.endSequence();
 
-        return buf.buf;
+        return buf.data();
     }
 
     function getTestDataBigInt() public pure returns(bytes memory) {
-        Buffer.buffer memory buf;
-        Buffer.init(buf, 128);
+        CBOR.CBORBuffer memory buf = CBOR.create(128);
 
         buf.startArray();
-        buf.encodeInt(type(int256).min);
-        buf.encodeInt(type(int256).min+1);
-        buf.encodeInt(int256(type(int64).min)-1);
-        buf.encodeInt(int256(type(int64).min)+1);
-        buf.encodeInt(type(int64).min);
-        buf.encodeInt(type(int64).max);
-        buf.encodeInt(int256(type(int64).max)+1);
-        buf.encodeInt(type(int256).max-1);
-        buf.encodeInt(type(int256).max);
+        buf.writeInt256(type(int256).min);
+        buf.writeInt256(type(int256).min+1);
+        buf.writeInt256(type(int256).max-1);
+        buf.writeInt256(type(int256).max);
+        buf.writeInt64(type(int64).min);
+        buf.writeInt64(type(int64).min+1);
+        buf.writeInt64(type(int64).max-1);
+        buf.writeInt64(type(int64).max);
         buf.endSequence();
 
-        return buf.buf;
+        return buf.data();
     }
 
     function getTestDataBigUint() public pure returns(bytes memory) {
-        Buffer.buffer memory buf;
-        Buffer.init(buf, 128);
+        CBOR.CBORBuffer memory buf = CBOR.create(128);
 
         buf.startArray();
-        buf.encodeUInt(0);
-        buf.encodeUInt(type(uint64).max);
-        buf.encodeUInt(uint256(type(uint64).max)+1);
-        buf.encodeUInt(type(uint256).max-1);
-        buf.encodeUInt(type(uint256).max);
+        buf.writeUInt256(type(uint256).min);
+        buf.writeUInt256(type(uint256).min+1);
+        buf.writeUInt256(type(uint256).max-1);
+        buf.writeUInt256(type(uint256).max);
         buf.endSequence();
 
-        return buf.buf;
+        return buf.data();
+    }
+
+    function getTestDataDefiniteLengthArray() public pure returns(bytes memory) {
+        CBOR.CBORBuffer memory buf = CBOR.create(128);
+
+        uint64 length = 1024;
+        buf.startFixedArray(length);
+        for (uint64 i = 0; i < length; i++) {
+            buf.writeInt64(int64(i));
+        }
+
+        return buf.data();
+    }
+
+    function getTestDataDefiniteLengthMap() public pure returns(bytes memory) {
+        CBOR.CBORBuffer memory buf = CBOR.create(128);
+
+        buf.startFixedMap(3);
+        buf.writeKVInt64("a", 100);
+        buf.writeKVInt64("b", 200);
+        buf.writeKVInt64("c", 300);
+
+        return buf.data();
+    }
+
+    function getTestDataInvalidCBOR() public pure returns(bytes memory) {
+        CBOR.CBORBuffer memory buf = CBOR.create(128);
+
+        buf.startArray();
+        buf.startArray();
+        buf.startArray();
+        buf.writeUInt256(type(uint256).min);
+        buf.endSequence();
+
+        return buf.data(); // this would revert()
     }
 }

--- a/test/testcbor.js
+++ b/test/testcbor.js
@@ -1,5 +1,6 @@
 const TestCBOR = artifacts.require('./TestCBOR.sol');
 const cbor = require('cbor');
+const truffleAssert = require('truffle-assertions');
 
 contract('CBOR', function(accounts) {
   it('returns valid CBOR-encoded data', async function() {
@@ -9,59 +10,72 @@ contract('CBOR', function(accounts) {
     assert.deepEqual(decoded, {
       'key1': 'value1',
       'long': 'This string is longer than 24 characters.',
+      'bytes': Buffer.from('Test'),
+      'true': true,
+      'false': false,
+      'null': null,
+      'undefined': undefined,
       'array': [0, 1, 23, 24, 0x100, 0x10000, 0x100000000, -42]
     });
   });
 
   it('returns > 8 byte int as bytes', async function() {
     var test = await TestCBOR.new();
-    var result = await test.getTestDataBigInt();
-
-    // js CBOR library doesn't support negative bignum encodings as described
-    // in the RFC, so we have to verify the raw codes
-    assert.equal(result, '0x' +
-      '9f' +                                       // array(*)
-        'c3' +                                     // tag(3)
-          '58' + '20' +                            // bytes(32)
-            '7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff' +   // "\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"
-        'c3' +                                     // tag(3)
-          '58' + '20' +                            // bytes(32)
-            '7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe' +   // "\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE"
-        '3b' + '8000000000000000' +                // negative(9223372036854775808)
-        '3b' + '7ffffffffffffffe' +                // negative(9223372036854775806)
-        '3b' + '7fffffffffffffff' +                // negative(9223372036854775807)
-        '1b' + '7fffffffffffffff' +                // unsigned(9223372036854775807)
-        '1b' + '8000000000000000' +                // unsigned(9223372036854775808)
-        'c2' +                                     // tag(2)
-          '58' + '20' +                            // bytes(32)
-            '7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe' +   // "\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE"
-        'c2' +                                     // tag(2)
-          '58' + '20' +                            // bytes(32)
-            '7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff' +   // "\x7F\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"
-      'ff'                                         // primitive(*)
-    );
+    var result = cbor.decodeFirstSync(new Buffer.from((await test.getTestDataBigInt()).slice(2), 'hex'));
+    expect(result.map((x) => x.toFixed())).to.deep.equal([
+      '-57896044618658097711785492504343953926634992332820282019728792003956564819968',
+      '-57896044618658097711785492504343953926634992332820282019728792003956564819967',
+      '57896044618658097711785492504343953926634992332820282019728792003956564819966',
+      '57896044618658097711785492504343953926634992332820282019728792003956564819967',
+      '-9223372036854775808',
+      '-9223372036854775807',
+      '9223372036854775806',
+      '9223372036854775807'
+    ]);
   });
 
   it('returns > 8 byte uint as bytes', async function() {
     var test = await TestCBOR.new();
-    var result = await test.getTestDataBigUint();
+    var result = cbor.decodeFirstSync(new Buffer.from((await test.getTestDataBigUint()).slice(2), 'hex'));
+    expect(result.map((x) => x.toFixed())).to.deep.equal([
+      '0',
+      '1',
+      '115792089237316195423570985008687907853269984665640564039457584007913129639934',
+      '115792089237316195423570985008687907853269984665640564039457584007913129639935'
+    ]);
+  });
 
-    // js CBOR library doesn't support negative bignum encodings as described
-    // in the RFC, so we have to verify the raw codes
-    assert.equal(result, '0x' +
-      '9f' +                                       // array(*)
-        '00' +                                     // unsigned(0)
-        '1b' + 'ffffffffffffffff' +                // unsigned(18446744073709551615)
-        'c2' +                                     // tag(2)
-          '58' + '20' +                            // bytes(32)
-            '0000000000000000000000000000000000000000000000010000000000000000' + // "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00"
-        'c2' +                                     // tag(2)
-          '58' + '20' +                            // bytes(32)
-            'fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe' + // "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE"
-        'c2' +                                     // tag(2)
-          '58' + '20' +                            // bytes(32)
-            'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff' + // "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"
-      'ff'                                         // primitive(*)
+  function toHexString(byteArray) {
+    return Array.from(byteArray, function(byte) {
+      return ('0' + (byte & 0xFF).toString(16)).slice(-2);
+    }).join('')
+  }
+
+  it('returns definite-length encoded array', async function() {
+    var test = await TestCBOR.new();
+    var expected = [];
+    for (let x = 0; x < 1024; x++) {
+      expected.push(x.toFixed())
+    }
+    var result = cbor.decodeFirstSync(new Buffer.from((await test.getTestDataDefiniteLengthArray()).slice(2), 'hex'));
+    expect(result.map((x) => x.toFixed())).to.deep.equal(expected);
+  });
+
+  it('returns definite-length encoded map', async function() {
+    var test = await TestCBOR.new();
+    var result = cbor.decodeFirstSync(new Buffer.from((await test.getTestDataDefiniteLengthMap()).slice(2), 'hex'));
+    expect(result).to.deep.equal({
+      "a": 100,
+      "b": 200,
+      "c": 300
+    });
+  });
+
+  it('reverts for invalid CBOR', async function() {
+    var test = await TestCBOR.new();
+    await truffleAssert.reverts(
+      test.getTestDataInvalidCBOR(),
+      "Invalid CBOR"
     );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4401,6 +4401,11 @@ lodash.escaperegexp@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -6669,6 +6674,14 @@ tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-2.2.1.tgz#c5bf04a5bbec3fd118be4084461b3a27c4d796bf"
   integrity sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==
+
+truffle-assertions@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/truffle-assertions/-/truffle-assertions-0.9.2.tgz#0f8360f53ad92b6d8fdb8ceb5dce54c1fc392e23"
+  integrity sha512-9g2RhaxU2F8DeWhqoGQvL/bV8QVoSnQ6PY+ZPvYRP5eF7+/8LExb4mjLx/FeliLTjc3Tv1SABG05Gu5qQ/ErmA==
+  dependencies:
+    assertion-error "^1.1.0"
+    lodash.isequal "^4.5.0"
 
 truffle@^5:
   version "5.1.56"


### PR DESCRIPTION
Summary:
1. Merged Nick's implementation: https://github.com/Arachnid/solidity-cborutils.
2. Added `startFixedArray` and `startFixedMap` methods.
3. Added new tests.
4. Tested against the new Buffer (PR is pending your review).

The new API is matching ensdomains project, but is a breaking change for Chainlink's contracts.
If we want backward compatibility, I can add methods to keep both new and old APIs.